### PR TITLE
adding icons to footer, add fragment

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -3,6 +3,17 @@ footer {
   margin-bottom: 0;
 }
 
+footer .icon {
+  padding-bottom: 0;
+}
+
+footer .icon::before {
+  transform: translateY(10px);
+  display: grid;
+  color: white;
+  height: 0;
+}
+
 .footer-wrapper {
   padding-bottom: 0;
 }

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -1,0 +1,1 @@
+/* if this isn't empty, the linter will complain */

--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -1,0 +1,48 @@
+/*
+ * Fragment Block
+ * Include content from one Helix page in another.
+ * https://www.hlx.live/developer/block-collection/fragment
+ */
+
+import {
+  decorateMain,
+} from '../../scripts/scripts.js';
+
+import {
+  loadBlocks,
+} from '../../scripts/lib-franklin.js';
+
+/**
+ * Loads a fragment.
+ * @param {string} path The path to the fragment
+ * @returns {HTMLElement} The root element of the fragment
+ */
+async function loadFragment(path) {
+  if (path && path.startsWith('/')) {
+    const resp = await fetch(`${path}.plain.html`);
+    if (resp.ok) {
+      const main = document.createElement('main');
+      main.innerHTML = await resp.text();
+      decorateMain(main);
+      await loadBlocks(main);
+      return main;
+    }
+  }
+  return null;
+}
+
+export default async function decorate(block) {
+  const link = block.querySelector('a');
+  const path = link ? link.getAttribute('href') : block.textContent.trim();
+  const fragment = await loadFragment(path);
+  if (fragment) {
+    const fragmentSection = fragment.querySelector(':scope .section');
+    if (fragmentSection) {
+      block.closest('.section')
+        .classList
+        .add(...fragmentSection.classList);
+      block.closest('.fragment-wrapper')
+        .replaceWith(...fragmentSection.childNodes);
+    }
+  }
+}


### PR DESCRIPTION
I realize that the way the footer was constructed, I can't easily add the sharing icons to it without restructuring the whole thing, so this PR only has the social icons.
I also added the fragment block and created a fragment for the sharing icons that can be used later.
Fix #57 

Test URLs:
- Before: https://main--fresenius--hlxsites.hlx.page/
- After: https://57-social--fresenius--hlxsites.hlx.page/
